### PR TITLE
Updated Indexing calls to new synchronous API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Indexing a document into a custom content source:
     }
   ]
   try:
-    document_receipts = client.index_documents(content_source_key, documents, timeout=10, delay=2)
-    print(document_receipts)
+    document_results = client.index_documents(content_source_key, documents, timeout=10, delay=2)
+    print(document_results)
   except SynchronousDocumentIndexingFailed:
     # Timed out before documents could finish indexing
     pass

--- a/swiftype_enterprise/__version__.py
+++ b/swiftype_enterprise/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'swiftype_enterprise'
 __description__ = 'An API client for Swiftype Enterprise'
 __url__ = 'https://github.com/swiftype/swiftype-enterprise-python'
-__version__ = '0.0.3'
+__version__ = '0.1.0'
 __author__ = 'Swiftype'
 __author_email__ = 'eng@swiftype.com'


### PR DESCRIPTION
This corresponds to changes made in the underlying API, which
no longer returns document receipts.